### PR TITLE
Improve DNS resolution and add retry logic for npm install

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -20,8 +20,12 @@ jobs:
     - name: Build ISO in Arch container
       run: |
         docker run --privileged --rm \
+          --dns 8.8.8.8 --dns 8.8.4.4 \
           -v ${{ github.workspace }}:/build \
           archlinux:latest bash -c "
+            # Ensure DNS resolution works inside chroot environments
+            echo 'nameserver 8.8.8.8' > /etc/resolv.conf
+            echo 'nameserver 8.8.4.4' >> /etc/resolv.conf
             pacman-key --init
             pacman -Syu --noconfirm archiso
             cd /build

--- a/airootfs/etc/pacman.d/hooks/40-install-claude-code.hook
+++ b/airootfs/etc/pacman.d/hooks/40-install-claude-code.hook
@@ -12,4 +12,5 @@ Description = Installing Claude Code globally via npm...
 When = PostTransaction
 Depends = nodejs
 Depends = npm
-Exec = /usr/bin/npm install -g @anthropic-ai/claude-code
+Depends = sh
+Exec = /bin/sh -c 'for attempt in 1 2 3 4 5; do echo "npm install attempt $attempt/5..."; npm install -g @anthropic-ai/claude-code && exit 0; echo "Attempt $attempt failed, waiting ${attempt}0s..."; sleep $((attempt * 10)); done; echo "All attempts failed"; exit 1'


### PR DESCRIPTION
## Summary
This PR improves the reliability of the ISO build process by fixing DNS resolution issues in the Docker container and adding retry logic to the npm package installation hook.

## Key Changes
- **DNS Configuration**: Added explicit DNS server configuration (Google's 8.8.8.8 and 8.8.4.4) to the Docker run command and ensured `/etc/resolv.conf` is properly configured inside the container to support chroot environments
- **npm Install Retry Logic**: Replaced the simple one-shot npm install command with a retry loop that attempts installation up to 5 times with exponential backoff (10s, 20s, 30s, 40s, 50s between attempts)
- **Hook Dependencies**: Added `sh` as an explicit dependency for the pacman hook to ensure the shell is available

## Implementation Details
The npm install retry mechanism uses a for loop that:
- Attempts installation up to 5 times
- Waits progressively longer between attempts (10 seconds × attempt number)
- Exits immediately on success
- Provides clear logging of each attempt
- Fails explicitly if all attempts are exhausted

These changes address transient network issues that can occur during the ISO build process, particularly in containerized environments where DNS resolution and package downloads may be unreliable.

https://claude.ai/code/session_0152yAXR7HS9TMDUs1JEk1Ht

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fmadkoding%2Fmad-os%2Fpull%2F7&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->