### PR TITLE
Fix content: 300MB RAM, Sway/Hyprland adaptive, persistent USB

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,7 @@ layout: none
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>madOS - AI-Orchestrated Arch Linux | Lightweight Linux with OpenCode</title>
-    <meta name="description" content="madOS: distribución Arch Linux optimizada para sistemas con poca RAM (1.9GB), con OpenCode integrado para orquestación inteligente. Sway, Nord theme, ~67MB RAM.">
+    <meta name="description" content="madOS: distribución Arch Linux optimizada para sistemas con poca RAM (1.9GB), con OpenCode integrado para orquestación inteligente. Sway/Hyprland, Nord theme, ~300MB RAM. USB persistente.">
 
     <!-- SEO -->
     <link rel="canonical" href="https://madkoding.github.io/mad-os/">
@@ -17,7 +17,7 @@ layout: none
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <meta name="author" content="madkoding">
     <meta name="generator" content="madOS Project">
-    <meta name="keywords" content="madOS, Arch Linux, OpenCode, AI, Linux, distribución, low RAM, lightweight, Sway, Wayland, Nord theme, AI orchestrated, operating system, open source, ZRAM, EarlyOOM, Intel Atom, GTK installer">
+    <meta name="keywords" content="madOS, Arch Linux, OpenCode, AI, Linux, distribución, low RAM, lightweight, Sway, Hyprland, Wayland, Nord theme, AI orchestrated, operating system, open source, ZRAM, EarlyOOM, Intel Atom, GTK installer, persistent USB, live USB">
     <meta name="theme-color" content="#88c0d0">
     <meta name="color-scheme" content="dark">
 
@@ -29,7 +29,7 @@ layout: none
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://madkoding.github.io/mad-os/">
     <meta property="og:title" content="madOS - AI-Orchestrated Arch Linux">
-    <meta property="og:description" content="Distribución Arch Linux optimizada para poca RAM (1.9GB) con OpenCode integrado para orquestación inteligente del sistema. Sway + Nord theme, ~67MB RAM.">
+    <meta property="og:description" content="Distribución Arch Linux optimizada para poca RAM (1.9GB) con OpenCode integrado para orquestación inteligente del sistema. Sway/Hyprland + Nord theme, ~300MB RAM. USB persistente.">
     <meta property="og:image" content="https://madkoding.github.io/mad-os/og-image.png">
     <meta property="og:image:type" content="image/png">
     <meta property="og:image:width" content="1200">
@@ -83,14 +83,15 @@ layout: none
         "featureList": [
             "OpenCode AI integration",
             "Optimized for 1.9GB RAM systems",
-            "Sway compositor with Nord theme (~67MB RAM)",
+            "Sway or Hyprland compositor with Nord theme (~300MB RAM)",
+            "Persistent USB live environment with auto-configured storage",
             "GTK graphical installer with 6 languages",
             "ZRAM and EarlyOOM memory optimization",
             "Built-in WiFi configuration",
             "UEFI and BIOS boot support",
             "Pre-installed development tools"
         ],
-        "keywords": "Arch Linux, AI, OpenCode, lightweight, low RAM, Sway, Wayland"
+        "keywords": "Arch Linux, AI, OpenCode, lightweight, low RAM, Sway, Hyprland, Wayland, persistent USB"
     }
     </script>
     <script type="application/ld+json">
@@ -175,7 +176,7 @@ layout: none
                     </div>
                     <div class="hero-stats">
                         <div class="stat">
-                            <span class="stat-value">~67<span class="stat-unit">MB</span></span>
+                            <span class="stat-value">~300<span class="stat-unit">MB</span></span>
                             <span class="stat-label" data-i18n="hero.stat.ram">Uso de RAM</span>
                         </div>
                         <div class="stat-divider"></div>
@@ -208,10 +209,10 @@ layout: none
                                 <pre class="neofetch-output">      /\        <span class="t-accent">user@madOS</span>
      /  \       <span class="t-muted">-----------</span>
     /\   \      <span class="t-label">OS:</span> madOS (Arch Linux)
-   /      \     <span class="t-label">WM:</span> Sway (Wayland)
+   /      \     <span class="t-label">WM:</span> Sway / Hyprland
   /   ,,   \    <span class="t-label">Theme:</span> Nord
  /   |  |   \   <span class="t-label">Terminal:</span> foot
-/_-''    ''-_\  <span class="t-label">RAM:</span> <span class="t-success">67MB</span> / 1.9GB</pre>
+/_-''    ''-_\  <span class="t-label">RAM:</span> <span class="t-success">300MB</span> / 1.9GB</pre>
                             </div>
                             <div class="terminal-line">
                                 <span class="t-prompt">$</span> <span class="t-cmd">sudo install-mados</span>
@@ -258,8 +259,8 @@ layout: none
                     <div class="feature-icon">
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
                     </div>
-                    <h3 data-i18n="feature.lightweight.title">Escritorio Ligero</h3>
-                    <p data-i18n="feature.lightweight.desc">Compositor Sway con tema Nord consume solo ~67MB de RAM para máximo rendimiento.</p>
+                    <h3 data-i18n="feature.lightweight.title">Escritorio Adaptable</h3>
+                    <p data-i18n="feature.lightweight.desc">Sway o Hyprland según tu hardware. Si hay aceleración 3D usa Hyprland, si no, Sway. Ambos con tema Nord y ~300MB de RAM.</p>
                 </div>
                 <div class="feature-card">
                     <div class="feature-icon">
@@ -284,10 +285,10 @@ layout: none
                 </div>
                 <div class="feature-card">
                     <div class="feature-icon">
-                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>
                     </div>
-                    <h3 data-i18n="feature.tuned.title">Ajustado al Máximo</h3>
-                    <p data-i18n="feature.tuned.desc">Optimizaciones de kernel, red y memoria para extraer el máximo rendimiento.</p>
+                    <h3 data-i18n="feature.persistent.title">USB Persistente</h3>
+                    <p data-i18n="feature.persistent.desc">Graba la ISO en un USB y úsala directo sin instalar. El espacio libre se autoconfigura como almacenamiento persistente.</p>
                 </div>
                 <div class="feature-card">
                     <div class="feature-icon">
@@ -312,8 +313,8 @@ layout: none
         <div class="container">
             <div class="section-header">
                 <span class="section-label" data-i18n="showcase.label">Entorno</span>
-                <h2 data-i18n="showcase.title">Escritorio Sway + Nord</h2>
-                <p data-i18n="showcase.subtitle">Un escritorio Wayland minimalista y elegante, diseñado para productividad</p>
+                <h2 data-i18n="showcase.title">Escritorio Wayland + Nord</h2>
+                <p data-i18n="showcase.subtitle">Sway o Hyprland según tu hardware, con tema Nord y configuración optimizada para productividad</p>
             </div>
             <div class="showcase-preview">
                 <div class="preview-frame">
@@ -321,7 +322,7 @@ layout: none
                         <div class="preview-dots">
                             <span></span><span></span><span></span>
                         </div>
-                        <span class="preview-title">Sway — madOS Desktop</span>
+                        <span class="preview-title">Sway / Hyprland — madOS Desktop</span>
                     </div>
                     <img src="mad-os-wallpaper.jpg" alt="madOS Desktop" class="preview-image" loading="lazy">
                 </div>
@@ -332,7 +333,11 @@ layout: none
                     <div class="app-list">
                         <div class="app-item">
                             <strong>Sway</strong>
-                            <span data-i18n="apps.desktop.sway">Compositor Wayland compatible con i3</span>
+                            <span data-i18n="apps.desktop.sway">Compositor Wayland (sin aceleración 3D)</span>
+                        </div>
+                        <div class="app-item">
+                            <strong>Hyprland</strong>
+                            <span data-i18n="apps.desktop.hyprland">Compositor Wayland (con aceleración 3D)</span>
                         </div>
                         <div class="app-item">
                             <strong>Waybar</strong>
@@ -436,7 +441,7 @@ layout: none
                         </div>
                         <div>
                             <strong data-i18n="hardware.gpu">GPU</strong>
-                            <p data-i18n="hardware.gpu.desc">Intel integrada (soporte para renderizado por software)</p>
+                            <p data-i18n="hardware.gpu.desc">Con aceleración 3D: Hyprland. Sin ella: Sway (renderizado por software)</p>
                         </div>
                     </div>
                     <div class="spec-item">
@@ -467,10 +472,10 @@ layout: none
                         <div class="monitor-stat">
                             <div class="monitor-meta">
                                 <span class="monitor-label" data-i18n="hardware.monitor.ram">RAM en uso</span>
-                                <span class="monitor-value">67MB / 1.9GB</span>
+                                <span class="monitor-value">300MB / 1.9GB</span>
                             </div>
                             <div class="monitor-bar">
-                                <div class="monitor-bar-fill" style="width: 3.5%"></div>
+                                <div class="monitor-bar-fill" style="width: 15.8%"></div>
                             </div>
                         </div>
                         <div class="monitor-stat">
@@ -559,21 +564,21 @@ layout: none
                         <div class="step-number">2</div>
                         <div class="step-content">
                             <h4 data-i18n="download.step2.title">Arrancar desde USB</h4>
-                            <p data-i18n="download.step2.desc">Espera a que Sway inicie automáticamente</p>
+                            <p data-i18n="download.step2.desc">El escritorio inicia automáticamente con almacenamiento persistente</p>
                         </div>
                     </div>
                     <div class="step">
                         <div class="step-number">3</div>
                         <div class="step-content">
-                            <h4 data-i18n="download.step3.title">Ejecutar Instalador</h4>
-                            <code>sudo install-mados</code>
+                            <h4 data-i18n="download.step3.title">Usar o Instalar</h4>
+                            <p data-i18n="download.step3.desc">Usa directo desde el USB o instala con el instalador GTK</p>
                         </div>
                     </div>
                     <div class="step">
                         <div class="step-number">4</div>
                         <div class="step-content">
                             <h4 data-i18n="download.step4.title">¡Disfruta madOS!</h4>
-                            <p data-i18n="download.step4.desc">Reinicia y comienza a usar tu sistema</p>
+                            <p data-i18n="download.step4.desc">Tus cambios persisten entre reinicios en el USB</p>
                         </div>
                     </div>
                 </div>

--- a/docs/translations.js
+++ b/docs/translations.js
@@ -39,16 +39,16 @@ const translations = {
         'feature.ai.desc': 'Asistente de IA integrado para orquestación inteligente del sistema y asistencia avanzada.',
         'feature.ram.title': 'Optimizado para Poca RAM',
         'feature.ram.desc': 'Diseñado específicamente para sistemas con 1.9GB RAM (Intel Atom) con ZRAM y EarlyOOM.',
-        'feature.lightweight.title': 'Escritorio Ligero',
-        'feature.lightweight.desc': 'Compositor Sway con tema Nord consume solo ~67MB de RAM para máximo rendimiento.',
+        'feature.lightweight.title': 'Escritorio Adaptable',
+        'feature.lightweight.desc': 'Sway o Hyprland según tu hardware. Si hay aceleración 3D usa Hyprland, si no, Sway. Ambos con tema Nord y ~300MB de RAM.',
         'feature.wifi.title': 'Configuración WiFi Integrada',
         'feature.wifi.desc': 'Conecta a tu red WiFi directamente desde el instalador. Escaneo automático de redes con soporte WPA2.',
         'feature.multilang.title': '6 Idiomas',
         'feature.multilang.desc': 'Instalador disponible en inglés, español, francés, alemán, chino y japonés con layout de teclado automático.',
         'feature.dev.title': 'Listo para Desarrollar',
         'feature.dev.desc': 'Node.js, npm, Git y VS Code pre-instalados para comenzar a programar inmediatamente.',
-        'feature.tuned.title': 'Ajustado al Máximo',
-        'feature.tuned.desc': 'Optimizaciones de kernel, red y memoria para extraer el máximo rendimiento.',
+        'feature.persistent.title': 'USB Persistente',
+        'feature.persistent.desc': 'Graba la ISO en un USB y úsala directo sin instalar. El espacio libre se autoconfigura como almacenamiento persistente.',
         'feature.installer.title': 'Instalador GTK',
         'feature.installer.desc': 'Instalador gráfico GTK con tema Nord, navegación intuitiva, progreso en tiempo real y boot splash animado.',
         'feature.security.title': 'Seguro por Defecto',
@@ -56,12 +56,13 @@ const translations = {
 
         // Showcase
         'showcase.label': 'Entorno',
-        'showcase.title': 'Escritorio Sway + Nord',
-        'showcase.subtitle': 'Un escritorio Wayland minimalista y elegante, diseñado para productividad',
+        'showcase.title': 'Escritorio Wayland + Nord',
+        'showcase.subtitle': 'Sway o Hyprland según tu hardware, con tema Nord y configuración optimizada para productividad',
 
         // Applications
         'apps.desktop': 'Entorno de Escritorio',
-        'apps.desktop.sway': 'Compositor Wayland compatible con i3',
+        'apps.desktop.sway': 'Compositor Wayland (sin aceleración 3D)',
+        'apps.desktop.hyprland': 'Compositor Wayland (con aceleración 3D)',
         'apps.desktop.waybar': 'Barra de estado personalizable',
         'apps.desktop.wofi': 'Lanzador de aplicaciones',
         'apps.desktop.foot': 'Emulador de terminal rápido',
@@ -86,7 +87,7 @@ const translations = {
         'hardware.ram': 'RAM',
         'hardware.ram.desc': '1.9GB mínimo (optimizado para memoria limitada)',
         'hardware.gpu': 'GPU',
-        'hardware.gpu.desc': 'Intel integrada (soporte para renderizado por software)',
+        'hardware.gpu.desc': 'Con aceleración 3D: Hyprland. Sin ella: Sway (renderizado por software)',
         'hardware.storage': 'Almacenamiento',
         'hardware.storage.desc': '32GB+ recomendado',
         'hardware.boot': 'Arranque',
@@ -112,10 +113,11 @@ const translations = {
         'download.steps.title': 'Pasos de Instalación',
         'download.step1.title': 'Crear USB Booteable',
         'download.step2.title': 'Arrancar desde USB',
-        'download.step2.desc': 'Espera a que Sway inicie automáticamente',
-        'download.step3.title': 'Ejecutar Instalador',
+        'download.step2.desc': 'El escritorio inicia automáticamente con almacenamiento persistente',
+        'download.step3.title': 'Usar o Instalar',
+        'download.step3.desc': 'Usa directo desde el USB o instala con el instalador GTK',
         'download.step4.title': '¡Disfruta madOS!',
-        'download.step4.desc': 'Reinicia y comienza a usar tu sistema',
+        'download.step4.desc': 'Tus cambios persisten entre reinicios en el USB',
 
         // Footer
         'footer.tagline': 'AI-Orchestrated Arch Linux System',
@@ -134,8 +136,8 @@ const translations = {
 
         // Meta
         'meta.title': 'madOS - AI-Orchestrated Arch Linux | Linux ligero con OpenCode',
-        'meta.description': 'madOS: distribución Arch Linux optimizada para sistemas con poca RAM (1.9GB), con OpenCode integrado para orquestación inteligente. Sway, Nord theme, ~67MB RAM.',
-        'meta.og.description': 'Distribución Arch Linux optimizada para poca RAM (1.9GB) con OpenCode integrado para orquestación inteligente del sistema. Sway + Nord theme, ~67MB RAM.',
+        'meta.description': 'madOS: distribución Arch Linux optimizada para sistemas con poca RAM (1.9GB), con OpenCode integrado para orquestación inteligente. Sway/Hyprland, Nord theme, ~300MB RAM. USB persistente.',
+        'meta.og.description': 'Distribución Arch Linux optimizada para poca RAM (1.9GB) con OpenCode integrado. Sway/Hyprland + Nord theme, ~300MB RAM. USB persistente auto-configurado.',
         'meta.og.image.alt': 'madOS - Distribución Arch Linux con IA integrada, vista previa de terminal y estadísticas clave',
         'meta.og.locale': 'es_ES'
     },
@@ -164,16 +166,16 @@ const translations = {
         'feature.ai.desc': 'Integrated AI assistant for intelligent system orchestration and advanced assistance.',
         'feature.ram.title': 'Optimized for Low RAM',
         'feature.ram.desc': 'Specifically designed for systems with 1.9GB RAM (Intel Atom) with ZRAM and EarlyOOM.',
-        'feature.lightweight.title': 'Lightweight Desktop',
-        'feature.lightweight.desc': 'Sway compositor with Nord theme uses only ~67MB RAM for maximum performance.',
+        'feature.lightweight.title': 'Adaptive Desktop',
+        'feature.lightweight.desc': 'Sway or Hyprland depending on your hardware. With 3D acceleration: Hyprland. Without: Sway. Both with Nord theme and ~300MB RAM.',
         'feature.wifi.title': 'Built-in WiFi Setup',
         'feature.wifi.desc': 'Connect to your WiFi network directly from the installer. Automatic network scanning with WPA2 support.',
         'feature.multilang.title': '6 Languages',
         'feature.multilang.desc': 'Installer available in English, Spanish, French, German, Chinese and Japanese with automatic keyboard layout.',
         'feature.dev.title': 'Ready to Develop',
         'feature.dev.desc': 'Node.js, npm, Git, and VS Code pre-installed to start coding immediately.',
-        'feature.tuned.title': 'Fully Tuned',
-        'feature.tuned.desc': 'Kernel, network, and memory optimizations to extract maximum performance.',
+        'feature.persistent.title': 'Persistent USB',
+        'feature.persistent.desc': 'Flash the ISO to a USB and use it directly without installing. Free space is auto-configured as persistent storage.',
         'feature.installer.title': 'GTK Installer',
         'feature.installer.desc': 'GTK graphical installer with Nord theme, intuitive navigation, real-time progress and animated boot splash.',
         'feature.security.title': 'Secure by Default',
@@ -181,12 +183,13 @@ const translations = {
 
         // Showcase
         'showcase.label': 'Environment',
-        'showcase.title': 'Sway + Nord Desktop',
-        'showcase.subtitle': 'A minimalist and elegant Wayland desktop, designed for productivity',
+        'showcase.title': 'Wayland + Nord Desktop',
+        'showcase.subtitle': 'Sway or Hyprland depending on your hardware, with Nord theme and optimized configuration for productivity',
 
         // Applications
         'apps.desktop': 'Desktop Environment',
-        'apps.desktop.sway': 'i3-compatible Wayland compositor',
+        'apps.desktop.sway': 'Wayland compositor (no 3D acceleration)',
+        'apps.desktop.hyprland': 'Wayland compositor (with 3D acceleration)',
         'apps.desktop.waybar': 'Customizable status bar',
         'apps.desktop.wofi': 'Application launcher',
         'apps.desktop.foot': 'Fast terminal emulator',
@@ -211,7 +214,7 @@ const translations = {
         'hardware.ram': 'RAM',
         'hardware.ram.desc': '1.9GB minimum (optimized for limited memory)',
         'hardware.gpu': 'GPU',
-        'hardware.gpu.desc': 'Intel integrated (software rendering support)',
+        'hardware.gpu.desc': 'With 3D acceleration: Hyprland. Without: Sway (software rendering)',
         'hardware.storage': 'Storage',
         'hardware.storage.desc': '32GB+ recommended',
         'hardware.boot': 'Boot',
@@ -237,10 +240,11 @@ const translations = {
         'download.steps.title': 'Installation Steps',
         'download.step1.title': 'Create Bootable USB',
         'download.step2.title': 'Boot from USB',
-        'download.step2.desc': 'Wait for Sway to start automatically',
-        'download.step3.title': 'Run Installer',
+        'download.step2.desc': 'Desktop starts automatically with persistent storage',
+        'download.step3.title': 'Use or Install',
+        'download.step3.desc': 'Use directly from USB or install with the GTK installer',
         'download.step4.title': 'Enjoy madOS!',
-        'download.step4.desc': 'Reboot and start using your system',
+        'download.step4.desc': 'Your changes persist across reboots on the USB',
 
         // Footer
         'footer.tagline': 'AI-Orchestrated Arch Linux System',
@@ -259,8 +263,8 @@ const translations = {
 
         // Meta
         'meta.title': 'madOS - AI-Orchestrated Arch Linux | Lightweight Linux with OpenCode',
-        'meta.description': 'madOS: Arch Linux distribution optimized for low-RAM systems (1.9GB), with OpenCode integrated for intelligent system orchestration. Sway, Nord theme, ~67MB RAM.',
-        'meta.og.description': 'Arch Linux distribution optimized for low-RAM systems (1.9GB) with OpenCode integrated for intelligent system orchestration. Sway + Nord theme, ~67MB RAM.',
+        'meta.description': 'madOS: Arch Linux distribution optimized for low-RAM systems (1.9GB), with OpenCode integrated for intelligent orchestration. Sway/Hyprland, Nord theme, ~300MB RAM. Persistent USB.',
+        'meta.og.description': 'Arch Linux distribution optimized for low-RAM systems (1.9GB) with OpenCode integrated. Sway/Hyprland + Nord theme, ~300MB RAM. Auto-configured persistent USB.',
         'meta.og.image.alt': 'madOS - AI-Orchestrated Arch Linux distribution with terminal preview and key stats',
         'meta.og.locale': 'en_US'
     }


### PR DESCRIPTION
- Update RAM usage from ~67MB to ~300MB across all stats, terminal, and system monitor
- Add Hyprland as compositor option alongside Sway, selected automatically based on 3D acceleration availability
- Replace "tuned" feature card with "Persistent USB" feature highlighting auto-configured persistent storage on live USB
- Update desktop showcase to reflect dual compositor support
- Add Hyprland to app listings with description
- Update GPU spec to explain Sway vs Hyprland selection criteria
- Revise installation steps to emphasize USB-first workflow: boot → use directly or install → changes persist
- Update all meta tags, SEO, and JSON-LD structured data
- Update both ES and EN translations with corrected content

https://claude.ai/code/session_012nh5bBC31B4jRX6Dz1H9iq

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fmadkoding%2Fmad-os%2Fpull%2F72&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->