### PR TITLE
refactor: persistence scripts, Ventoy support, equalizer backend & tests

### DIFF
--- a/airootfs/etc/sway/config.d/50-installer-autostart.conf
+++ b/airootfs/etc/sway/config.d/50-installer-autostart.conf
@@ -2,25 +2,13 @@
 # Only launch in live environment (check for archiso)
 # Skip if booted via Ventoy (persistence is already configured)
 
-# Check if running in Ventoy
-is_ventoy_boot() {
-    if [ -f /proc/cmdline ]; then
-        cat /proc/cmdline | grep -q "ventoy" && return 0
-    fi
-    return 1
-}
+# Window rules for the installer
+for_window [app_id="install-mados"] floating enable
+for_window [app_id="install-mados"] resize set 900 650
+for_window [app_id="install-mados"] move position center
+for_window [title="madOS"] floating enable
+for_window [title="madOS"] resize set 900 650
+for_window [title="madOS"] move position center
 
-# Only launch installer if NOT in Ventoy mode
-if [ -d /run/archiso ] && ! is_ventoy_boot; then
-    # Window rules for the installer
-    for_window [app_id="install-mados"] floating enable
-    for_window [app_id="install-mados"] resize set 900 650
-    for_window [app_id="install-mados"] move position center
-    for_window [title="madOS"] floating enable
-    for_window [title="madOS"] resize set 900 650
-    for_window [title="madOS"] move position center
-
-    # Auto-launch installer after a short delay (let Sway fully initialize)
-    # Pass Wayland env vars through sudo so GTK can connect to the display
-    exec sleep 2 && sudo WAYLAND_DISPLAY=$WAYLAND_DISPLAY XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR /usr/local/bin/install-mados
-fi
+# Auto-launch installer via helper script (handles Ventoy/archiso checks)
+exec /usr/local/bin/mados-installer-autostart

--- a/airootfs/etc/systemd/system/mados-persist-sync.service
+++ b/airootfs/etc/systemd/system/mados-persist-sync.service
@@ -1,14 +1,15 @@
 [Unit]
-Description=mados Persistence Sync (Ventoy-style)
-After=multi-user.target
-Wants=network-online.target
+Description=madOS Persistence Sync (rsync-based)
+After=mados-persistence-detect.service
+Requires=mados-persistence-detect.service
 
 [Service]
-Type=forking
+Type=simple
 ExecStart=/usr/local/bin/mados-persist-sync.sh start
 ExecStop=/usr/local/bin/mados-persist-sync.sh stop
 Restart=on-failure
-RestartSec=10
+RestartSec=30
+TimeoutStopSec=60
 
 [Install]
 WantedBy=multi-user.target

--- a/airootfs/etc/systemd/system/mados-persistence-detect.service
+++ b/airootfs/etc/systemd/system/mados-persistence-detect.service
@@ -1,9 +1,8 @@
 [Unit]
-Description=mados Persistence Detection
-DefaultDependencies=no
-After=systemd-remount-fs.service
-Before=local-fs-pre.target
-Wants=local-fs-pre.target
+Description=madOS Persistence Mount
+After=mados-ventoy-setup.service local-fs.target
+Requires=mados-ventoy-setup.service
+Before=mados-persist-sync.service
 
 [Service]
 Type=oneshot

--- a/airootfs/etc/systemd/system/mados-ventoy-setup.service
+++ b/airootfs/etc/systemd/system/mados-ventoy-setup.service
@@ -1,9 +1,8 @@
 [Unit]
-Description=mados Ventoy Auto-Persistence Setup
+Description=madOS Persistence Detection
 DefaultDependencies=no
-After=systemd-remount-fs.service
-After=local-fs-pre.target
-Before=local-fs.target
+After=systemd-remount-fs.service local-fs.target
+Before=mados-persistence-detect.service
 
 [Service]
 Type=oneshot

--- a/airootfs/etc/systemd/system/multi-user.target.wants/mados-persist-sync.service
+++ b/airootfs/etc/systemd/system/multi-user.target.wants/mados-persist-sync.service
@@ -1,0 +1,1 @@
+/etc/systemd/system/mados-persist-sync.service

--- a/airootfs/etc/systemd/system/multi-user.target.wants/mados-persistence-detect.service
+++ b/airootfs/etc/systemd/system/multi-user.target.wants/mados-persistence-detect.service
@@ -1,0 +1,1 @@
+/etc/systemd/system/mados-persistence-detect.service

--- a/airootfs/usr/local/bin/mados-installer-autostart
+++ b/airootfs/usr/local/bin/mados-installer-autostart
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# madOS Installer Autostart Helper
+# Launched by Sway config - checks conditions and starts the GTK installer
+# Only runs in live environment (archiso) and NOT when booted via Ventoy
+
+is_ventoy_boot() {
+    if [ -f /proc/cmdline ]; then
+        grep -q "ventoy" /proc/cmdline && return 0
+    fi
+    return 1
+}
+
+# Only launch installer if in archiso live environment and NOT in Ventoy mode
+if [ -d /run/archiso ] && ! is_ventoy_boot; then
+    sleep 2
+    sudo WAYLAND_DISPLAY="$WAYLAND_DISPLAY" XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" /usr/local/bin/install-mados
+fi

--- a/airootfs/usr/local/bin/mados-persist-detect.sh
+++ b/airootfs/usr/local/bin/mados-persist-detect.sh
@@ -1,150 +1,98 @@
 #!/bin/bash
+# =============================================================================
+# mados-persist-detect.sh - Persistence State Reader
+# =============================================================================
+# Reads persistence state written by mados-ventoy-setup.sh and makes
+# persistence data available to the system.
+#
+# State is stored in /run/mados-persist.env with these variables:
+#   MADOS_PERSIST_MODE    = cow_device|cow_label|partition|file|none
+#   MADOS_PERSIST_DEVICE  = device path or file path
+#   MADOS_PERSIST_VENTOY  = 1 if booted via Ventoy, 0 otherwise
+#   MADOS_PERSIST_ACTIVE  = 1 if any persistence is active, 0 otherwise
+# =============================================================================
 
-PERSISTENCE_FILE=""
+STATE_FILE="/run/mados-persist.env"
 PERSISTENCE_MOUNT="/mnt/mados-persist"
 
-find_persistence_file() {
-    local boot_dev="$1"
-    
-    for file in "$boot_dev/mados-persistence.dat" \
-                "$boot_dev/ventoy/mados-persistence.dat" \
-                "/isodevice/mados-persistence.dat"; do
-        if [ -f "$file" ]; then
-            PERSISTENCE_FILE="$file"
-            return 0
-        fi
-    done
-    
-    for label in "mados-persist" "vtoycow" "casper-rw" "persistence"; do
-        local device=$(blkid -L "$label" 2>/dev/null)
-        if [ -n "$device" ] && [ -b "$device" ]; then
-            PERSISTENCE_FILE="$device"
-            return 0
-        fi
-    done
-    
-    return 1
+log() {
+    echo "[mados-persist-detect] $1"
 }
 
-find_boot_device() {
-    local root_dev=""
-    
-    if [ -f /proc/cmdline ]; then
-        local cmdline=$(cat /proc/cmdline)
-        
-        for param in $cmdline; do
-            case "$param" in
-                archisosearchuuid=*)
-                    local uuid="${param#*=}"
-                    root_dev=$(blkid -U "$uuid" 2>/dev/null)
-                    break
-                    ;;
-            esac
-        done
-    fi
-    
-    if [ -z "$root_dev" ] && [ -d /run/archiso/bootmnt ]; then
-        root_dev=$(df /run/archiso/bootmnt 2>/dev/null | tail -1 | awk '{print $1}')
-    fi
-    
-    if [ -n "$root_dev" ]; then
-        local dev_name=$(basename "$root_dev")
-        local dev_base="/dev/${dev_name%%[0-9]*}"
-        local part_num="${root_dev##*[^0-9]}"
-        
-        if [ "$part_num" -gt 1 ]; then
-            echo "${dev_base}${((part_num - 1))}"
-        else
-            echo "${dev_base}"
-        fi
-    fi
-}
-
-setup_archiso_persistence() {
-    local persist_file="$1"
-    
-    local cow_device=""
-    local cow_label=""
-    
-    if [[ "$persist_file" == /dev/* ]]; then
-        cow_device="$persist_file"
-    else
-        if [[ "$persist_file" == *.dat ]]; then
-            local loop_dev=$(losetup -f --show "$persist_file" 2>/dev/null)
-            if [ -n "$loop_dev" ]; then
-                cow_device="$loop_dev"
-            fi
-        fi
-        
-        if [ -z "$cow_device" ] && [ -f "$persist_file" ]; then
-            cow_device="$persist_file"
-        fi
-    fi
-    
-    if [ -n "$cow_device" ]; then
-        local cow_dir="/run/archiso/cowspace"
-        
-        if [ ! -d "$cow_dir" ]; then
-            cow_dir="/.snapshots"
-            mkdir -p "$cow_dir"
-        fi
-        
-        mount --bind "$cow_dir" "$cow_dir" 2>/dev/null || true
-        
-        export MADOS_PERSISTENCE_DEVICE="$cow_device"
-        export MADOS_PERSISTENCE_ACTIVE=1
-        
+read_state() {
+    if [ -f "$STATE_FILE" ]; then
+        # shellcheck source=/dev/null
+        . "$STATE_FILE"
         return 0
     fi
-    
     return 1
 }
 
-mount_persistence_dat() {
+mount_persistence_source() {
     local source="$1"
     local target="$PERSISTENCE_MOUNT"
-    
+
     mkdir -p "$target"
-    
-    if [[ "$source" == /dev/* ]]; then
-        mount -o rw "$source" "$target"
-    else
-        local loop_dev=$(losetup -f --show "$source")
-        mount -o rw "$loop_dev" "$target"
+
+    # If already mounted, skip
+    if mountpoint -q "$target" 2>/dev/null; then
+        log "Already mounted at $target"
+        return 0
     fi
-    
-    echo "$target"
+
+    if [[ "$source" == /dev/* ]]; then
+        # Block device - mount directly
+        mount -o rw "$source" "$target" 2>/dev/null
+        return $?
+    elif [[ -f "$source" ]]; then
+        # File (.dat) - set up loop device
+        local loop_dev
+        loop_dev=$(losetup -f --show "$source" 2>/dev/null)
+        if [ -z "$loop_dev" ]; then
+            log "ERROR: Failed to create loop device for $source"
+            return 1
+        fi
+        mount -o rw "$loop_dev" "$target" 2>/dev/null
+        return $?
+    fi
+
+    log "ERROR: Unknown source type: $source"
+    return 1
 }
 
 main() {
-    echo "[mados-persist] Starting persistence detection..."
-    
-    local boot_dev=$(find_boot_device)
-    if [ -z "$boot_dev" ]; then
-        echo "[mados-persist] Could not find boot device, using tmpfs mode"
+    log "Reading persistence state..."
+
+    if ! read_state; then
+        log "No state file found at $STATE_FILE"
+        log "Run mados-ventoy-setup.service first"
         exit 0
     fi
-    
-    echo "[mados-persist] Boot device: $boot_dev"
-    
-    if find_persistence_file "$boot_dev"; then
-        echo "[mados-persist] Found persistence: $PERSISTENCE_FILE"
-        
-        if setup_archiso_persistence "$PERSISTENCE_FILE"; then
-            echo "[mados-persist] Archiso persistence configured: $MADOS_PERSISTENCE_DEVICE"
-        else
-            local persist_dir=$(mount_persistence_dat "$PERSISTENCE_FILE")
-            if [ -d "$persist_dir" ]; then
-                echo "[mados-persist] Persistence mounted at: $persist_dir"
-                export MADOS_PERSISTENCE_DIR="$persist_dir"
+
+    log "Mode: ${MADOS_PERSIST_MODE:-none}"
+    log "Device: ${MADOS_PERSIST_DEVICE:-none}"
+    log "Ventoy: ${MADOS_PERSIST_VENTOY:-0}"
+    log "Active: ${MADOS_PERSIST_ACTIVE:-0}"
+
+    case "$MADOS_PERSIST_MODE" in
+        cow_device|cow_label)
+            # Archiso handles this natively via overlay - nothing to do
+            log "Archiso overlay persistence is active, no extra setup needed"
+            ;;
+        partition|file)
+            # rsync-based persistence: mount the source for the sync service
+            if [ -n "$MADOS_PERSIST_DEVICE" ]; then
+                if mount_persistence_source "$MADOS_PERSIST_DEVICE"; then
+                    log "Persistence source mounted at $PERSISTENCE_MOUNT"
+                else
+                    log "WARNING: Failed to mount persistence source"
+                fi
             fi
-        fi
-        
-        export MADOS_PERSISTENCE_ACTIVE=1
-        echo "[mados-persist] Persistence is active"
-    else
-        echo "[mados-persist] No persistence file found, using tmpfs mode"
-    fi
+            ;;
+        none|*)
+            log "No persistence active"
+            ;;
+    esac
 }
 
 main "$@"

--- a/airootfs/usr/local/bin/mados-persist-sync.sh
+++ b/airootfs/usr/local/bin/mados-persist-sync.sh
@@ -1,6 +1,25 @@
 #!/bin/bash
+# =============================================================================
+# mados-persist-sync.sh - Periodic rsync-based Persistence Service
+# =============================================================================
+# This service provides "soft" persistence by periodically syncing user data
+# between the live system and a mounted persistence partition/file.
+#
+# It reads state from /run/mados-persist.env (written by mados-ventoy-setup.sh)
+# and only runs when:
+#   - MADOS_PERSIST_MODE is "partition" or "file" (rsync mode)
+#   - The persistence mount at /mnt/mados-persist is available
+#
+# For cow_device/cow_label modes, archiso handles persistence natively
+# and this service is not needed.
+#
+# Synced directories:
+#   /home/         → persist/home/
+#   /root/         → persist/root/
+#   /etc/mados/    → persist/etc.mados/
+# =============================================================================
 
-PERSISTENCE_FILE="/mados-persistence.dat"
+STATE_FILE="/run/mados-persist.env"
 PERSISTENCE_MOUNT="/mnt/mados-persist"
 SYNC_INTERVAL=300
 LOG_FILE="/var/log/mados-persist.log"
@@ -9,171 +28,140 @@ log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE" 2>/dev/null
 }
 
-find_persistence_file() {
-    local boot_dev=""
-    local persist_file=""
-    
-    if [[ -d /run/archiso/bootmnt ]]; then
-        boot_dev="/run/archiso/bootmnt"
-        
-        for file in "${boot_dev}${PERSISTENCE_FILE}" \
-                    "${boot_dev}/ventoy${PERSISTENCE_FILE}"; do
-            if [[ -f "$file" ]]; then
-                persist_file="$file"
-                echo "$persist_file"
-                return 0
-            fi
-        done
+read_state() {
+    if [ -f "$STATE_FILE" ]; then
+        # shellcheck source=/dev/null
+        . "$STATE_FILE"
+        return 0
     fi
-    
-    for label in "mados-persist" "vtoycow"; do
-        local device
-        device=$(blkid -L "$label" 2>/dev/null)
-        if [[ -n "$device" ]]; then
-            echo "$device"
-            return 0
-        fi
-    done
-    
     return 1
 }
 
-mount_persistence() {
-    local source="$1"
-    
-    mkdir -p "$PERSISTENCE_MOUNT"
-    
-    if [[ "$source" == /dev/* ]]; then
-        mount -o rw "$source" "$PERSISTENCE_MOUNT"
-    else
-        local loop_dev
-        loop_dev=$(losetup -f --show "$source" 2>/dev/null)
-        if [[ -z "$loop_dev" ]]; then
-            log "ERROR: Failed to create loop device"
-            return 1
-        fi
-        mount -o rw "$loop_dev" "$PERSISTENCE_MOUNT"
-    fi
-    
-    return $?
+is_rsync_mode() {
+    read_state || return 1
+    case "$MADOS_PERSIST_MODE" in
+        partition|file) return 0 ;;
+        *) return 1 ;;
+    esac
 }
 
-sync_home_to_persistence() {
+is_persistence_mounted() {
+    mountpoint -q "$PERSISTENCE_MOUNT" 2>/dev/null
+}
+
+sync_to_persistence() {
     local persist_dir="$PERSISTENCE_MOUNT"
-    
-    if [[ ! -d "$persist_dir" ]]; then
+
+    if ! is_persistence_mounted; then
+        log "WARNING: Persistence not mounted at $persist_dir"
         return 1
     fi
-    
+
     log "Syncing to persistence..."
-    
-    # /home - archivos y configuración de usuario
+
+    # /home - user files and configuration
     rsync -a --delete \
         --exclude='.cache' \
         --exclude='.local/share/Trash' \
         --exclude='.thumbnails' \
         --exclude='.npm/_cacache' \
-        --exclude='.node_modules/.cache' \
         /home/ "$persist_dir/home/" 2>/dev/null
-    
-    # /root - configuración de root
+
+    # /root - root configuration
     rsync -a --delete \
         --exclude='.cache' \
         --exclude='.local/share/Trash' \
         /root/ "$persist_dir/root/" 2>/dev/null
-    
-    # /usr/local - binarios y scripts instalados
-    rsync -a --delete \
-        --exclude='/bin' \
-        --exclude='/sbin' \
-        --exclude='/lib' \
-        /usr/local/ "$persist_dir/usr.local/" 2>/dev/null
-    
-    # /var/cache/pacman - paquetes descargados (ahorra bandwidth)
-    rsync -a --delete \
-        /var/cache/pacman/ "$persist_dir/pacman/pkg/" 2>/dev/null
-    
+
+    # /etc/mados - madOS configuration
+    if [ -d /etc/mados ]; then
+        mkdir -p "$persist_dir/etc.mados/"
+        rsync -a --delete \
+            /etc/mados/ "$persist_dir/etc.mados/" 2>/dev/null
+    fi
+
+    log "Sync complete"
     return 0
 }
 
-load_persistence_to_home() {
+load_from_persistence() {
     local persist_dir="$PERSISTENCE_MOUNT"
-    
-    if [[ ! -d "$persist_dir" ]] || [[ -z "$(ls -A "$persist_dir" 2>/dev/null)" ]]; then
+
+    if ! is_persistence_mounted; then
         return 1
     fi
-    
-    log "Loading persistence..."
-    
+
+    if [ -z "$(ls -A "$persist_dir" 2>/dev/null)" ]; then
+        log "Persistence mount is empty, nothing to load"
+        return 1
+    fi
+
+    log "Loading persisted data..."
+
     # /home
-    if [[ -d "$persist_dir/home" ]]; then
+    if [ -d "$persist_dir/home" ]; then
         rsync -a "$persist_dir/home/" /home/ 2>/dev/null
+        log "Restored /home"
     fi
-    
+
     # /root
-    if [[ -d "$persist_dir/root" ]]; then
+    if [ -d "$persist_dir/root" ]; then
         rsync -a "$persist_dir/root/" /root/ 2>/dev/null
+        log "Restored /root"
     fi
-    
-    # /usr/local
-    if [[ -d "$persist_dir/usr.local" ]]; then
-        rsync -a "$persist_dir/usr.local/" /usr/local/ 2>/dev/null
+
+    # /etc/mados
+    if [ -d "$persist_dir/etc.mados" ]; then
+        mkdir -p /etc/mados
+        rsync -a "$persist_dir/etc.mados/" /etc/mados/ 2>/dev/null
+        log "Restored /etc/mados"
     fi
-    
-    # /var/cache/pacman
-    if [[ -d "$persist_dir/pacman/pkg" ]]; then
-        mkdir -p /var/cache/pacman/pkg
-        rsync -a "$persist_dir/pacman/pkg/" /var/cache/pacman/pkg/ 2>/dev/null
-    fi
-    
+
     return 0
 }
 
 start_service() {
-    log "=== Starting persistence service ==="
-    
-    local persist_file
-    persist_file=$(find_persistence_file)
-    
-    if [[ -z "$persist_file" ]]; then
-        log "No persistence file found. Persistence disabled."
-        return 0
+    log "=== Starting persistence sync service ==="
+
+    if ! is_rsync_mode; then
+        local mode="${MADOS_PERSIST_MODE:-unknown}"
+        if [ "$mode" = "cow_device" ] || [ "$mode" = "cow_label" ]; then
+            log "Archiso native persistence active, rsync not needed"
+        else
+            log "No rsync-based persistence configured (mode=$mode)"
+        fi
+        exit 0
     fi
-    
-    log "Found: $persist_file"
-    
-    if ! mount_persistence "$persist_file"; then
-        log "Failed to mount. Running without persistence."
-        return 1
+
+    if ! is_persistence_mounted; then
+        log "Persistence not mounted at $PERSISTENCE_MOUNT, cannot start"
+        log "Ensure mados-persistence-detect.service ran successfully"
+        exit 1
     fi
-    
+
     log "Persistence mounted at: $PERSISTENCE_MOUNT"
-    
-    load_persistence_to_home
-    
-    log "Sync loop started (every ${SYNC_INTERVAL}s)"
-    
+
+    # Load previous persisted data
+    load_from_persistence
+
+    log "Starting sync loop (every ${SYNC_INTERVAL}s)"
+
+    # Sync periodically (this runs as Type=simple, blocks here)
     while true; do
         sleep "$SYNC_INTERVAL"
-        sync_home_to_persistence
+        sync_to_persistence
     done
 }
 
 stop_service() {
-    log "Stopping persistence..."
-    sync_home_to_persistence
-    
-    for loop_dev in $(losetup -j "$PERSISTENCE_MOUNT"/* 2>/dev/null | cut -d: -f1); do
-        losetup -d "$loop_dev" 2>/dev/null || true
-    done
-    
-    umount "$PERSISTENCE_MOUNT" 2>/dev/null || true
-    return 0
+    log "Stopping persistence sync..."
+    sync_to_persistence
+    log "Final sync complete"
 }
 
 case "${1:-start}" in
     start) start_service ;;
     stop)  stop_service ;;
-    sync)  sync_home_to_persistence ;;
+    sync)  sync_to_persistence ;;
     *)     echo "Usage: $0 {start|stop|sync}" ;;
 esac

--- a/airootfs/usr/local/bin/mados-persistence
+++ b/airootfs/usr/local/bin/mados-persistence
@@ -1,8 +1,15 @@
 #!/bin/bash
+# =============================================================================
+# mados-persistence - User-facing CLI for persistence management
+# =============================================================================
+# Usage:
+#   mados-persistence status   # Show persistence status
+#   mados-persistence info     # Show setup instructions
+#   mados-persistence sync     # Force manual sync (rsync mode only)
+# =============================================================================
 
-PERSISTENCE_FILE="/mados-persistence.dat"
+STATE_FILE="/run/mados-persist.env"
 PERSISTENCE_MOUNT="/mnt/mados-persist"
-MOUNTED_PERSIST=""
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -10,211 +17,148 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-print_status() {
-    echo -e "${GREEN}mados-persistence${NC} - Ventoy-style persistent USB manager"
-    echo ""
-}
+read_state() {
+    MADOS_PERSIST_MODE="none"
+    MADOS_PERSIST_DEVICE=""
+    MADOS_PERSIST_VENTOY="0"
+    MADOS_PERSIST_ACTIVE="0"
 
-detect_persistence() {
-    local boot_dev=""
-    
-    if [ -d /run/archiso/bootmnt ]; then
-        boot_dev="/run/archiso/bootmnt"
-    elif [ -f /proc/cmdline ]; then
-        local cmdline=$(cat /proc/cmdline)
-        for param in $cmdline; do
-            case "$param" in
-                archisosearchuuid=*)
-                    local uuid="${param#*=}"
-                    boot_dev=$(blkid -U "$uuid" 2>/dev/null)
-                    boot_dev=$(dirname "$boot_dev")
-                    break
-                    ;;
-            esac
-        done
+    if [ -f "$STATE_FILE" ]; then
+        # shellcheck source=/dev/null
+        . "$STATE_FILE"
     fi
-    
-    if [ -n "$boot_dev" ]; then
-        if [ -f "${boot_dev}${PERSISTENCE_FILE}" ]; then
-            echo "${boot_dev}${PERSISTENCE_FILE}"
-            return 0
-        elif [ -f "${boot_dev}/ventoy${PERSISTENCE_FILE}" ]; then
-            echo "${boot_dev}/ventoy${PERSISTENCE_FILE}"
-            return 0
-        fi
-    fi
-    
-    for label in "mados-persist" "vtoycow" "persistence"; do
-        local device=$(blkid -L "$label" 2>/dev/null)
-        if [ -n "$device" ]; then
-            echo "$device"
-            return 0
-        fi
-    done
-    
-    return 1
-}
-
-check_ventoy_mode() {
-    if [ -f /proc/cmdline ]; then
-        local cmdline=$(cat /proc/cmdline)
-        for param in $cmdline; do
-            case "$param" in
-                cow_device=*)
-                    return 0
-                    ;;
-            esac
-        done
-    fi
-    return 1
 }
 
 cmd_status() {
-    echo "=== Persistence Status ==="
+    read_state
+
+    echo -e "${BLUE}=== madOS Persistence Status ===${NC}"
     echo ""
-    
-    if check_ventoy_mode; then
-        echo -e "${GREEN}Mode: Ventoy cow_device (native persistence)${NC}"
-    elif [ -n "$MADOS_PERSISTENCE_ACTIVE" ]; then
-        echo -e "${GREEN}Persistence: ACTIVE (file-based)${NC}"
+
+    case "$MADOS_PERSIST_MODE" in
+        cow_device)
+            echo -e "${GREEN}Mode: Archiso cow_device (native transparent persistence)${NC}"
+            echo -e "Device: ${MADOS_PERSIST_DEVICE}"
+            echo -e "All changes are saved ${GREEN}automatically${NC} to the device."
+            echo "No sync needed."
+            ;;
+        cow_label)
+            echo -e "${GREEN}Mode: Archiso cow_label (native transparent persistence)${NC}"
+            echo -e "Device: ${MADOS_PERSIST_DEVICE}"
+            echo -e "All changes are saved ${GREEN}automatically${NC} via overlay."
+            echo "No sync needed."
+            ;;
+        partition)
+            echo -e "${GREEN}Mode: rsync-based (partition)${NC}"
+            echo -e "Device: ${MADOS_PERSIST_DEVICE}"
+            if mountpoint -q "$PERSISTENCE_MOUNT" 2>/dev/null; then
+                echo -e "Mount: ${GREEN}$PERSISTENCE_MOUNT (mounted)${NC}"
+                local used
+                used=$(df -h "$PERSISTENCE_MOUNT" 2>/dev/null | tail -1 | awk '{print $3 "/" $2 " (" $5 ")"}')
+                echo -e "Usage: $used"
+            else
+                echo -e "Mount: ${RED}Not mounted${NC}"
+            fi
+            echo ""
+            echo "Data is synced every 5 minutes (home, root, configs)."
+            echo "Force sync: sudo mados-persistence sync"
+            ;;
+        file)
+            echo -e "${GREEN}Mode: rsync-based (file)${NC}"
+            echo -e "File: ${MADOS_PERSIST_DEVICE}"
+            if mountpoint -q "$PERSISTENCE_MOUNT" 2>/dev/null; then
+                echo -e "Mount: ${GREEN}$PERSISTENCE_MOUNT (mounted)${NC}"
+            else
+                echo -e "Mount: ${RED}Not mounted${NC}"
+            fi
+            echo ""
+            echo "Data is synced every 5 minutes (home, root, configs)."
+            echo "Force sync: sudo mados-persistence sync"
+            ;;
+        *)
+            echo -e "${YELLOW}Persistence: INACTIVE${NC}"
+            echo ""
+            echo "Changes will be lost on reboot."
+            echo "Run 'mados-persistence info' to see how to enable persistence."
+            ;;
+    esac
+
+    echo ""
+    if [ "$MADOS_PERSIST_VENTOY" = "1" ]; then
+        echo -e "Boot method: ${BLUE}Ventoy${NC}"
+    elif [ -d /run/archiso ]; then
+        echo -e "Boot method: ${BLUE}Direct USB/ISO${NC}"
     else
-        echo -e "${YELLOW}Persistence: INACTIVE${NC}"
-    fi
-    
-    if [ -n "$MADOS_PERSISTENCE_DIR" ]; then
-        echo "Persistence directory: $MADOS_PERSISTENCE_DIR"
-    fi
-    
-    if [ -n "$MADOS_PERSISTENCE_DEVICE" ]; then
-        echo "Persistence device: $MADOS_PERSISTENCE_DEVICE"
-    fi
-    
-    echo ""
-    echo "=== Looking for persistence file on boot device ==="
-    
-    if detect_persistence; then
-        echo -e "${GREEN}Found persistence file/partition${NC}"
-    else
-        echo -e "${RED}No persistence file found${NC}"
-    fi
-    
-    echo ""
-    echo "=== Boot parameters ==="
-    if [ -f /proc/cmdline ]; then
-        grep -oE 'cow_spacesize=[^ ]+' /proc/cmdline 2>/dev/null || echo "No cow_spacesize parameter"
-        grep -oE 'cow_device=[^ ]+' /proc/cmdline 2>/dev/null || echo "No cow_device parameter (Ventoy sets this automatically)"
+        echo -e "Boot method: ${BLUE}Installed system${NC}"
     fi
 }
 
-cmd_enable() {
-    echo "=== Enabling Persistence ==="
-    
-    if check_ventoy_mode; then
-        echo -e "${GREEN}Already in Ventoy cow_device mode!${NC}"
-        echo "Your changes are being saved automatically to the .dat file"
-        exit 0
-    fi
-    
-    local persist_file=$(detect_persistence)
-    
-    if [ -z "$persist_file" ]; then
-        echo -e "${RED}No persistence file found!${NC}"
-        echo ""
-        echo "To create a persistence file:"
-        echo "  1. Run: sudo mados-persistence-img.sh -s 4096"
-        echo "  2. Copy the file to your USB as 'mados-persistence.dat'"
-        echo "  3. Or create a partition with label 'mados-persist'"
+cmd_sync() {
+    read_state
+
+    if [ "$MADOS_PERSIST_MODE" = "partition" ] || [ "$MADOS_PERSIST_MODE" = "file" ]; then
+        echo "Forcing sync..."
+        /usr/local/bin/mados-persist-sync.sh sync
+        echo -e "${GREEN}Sync complete!${NC}"
+    elif [ "$MADOS_PERSIST_MODE" = "cow_device" ] || [ "$MADOS_PERSIST_MODE" = "cow_label" ]; then
+        echo -e "${GREEN}Native persistence active. Changes are saved automatically.${NC}"
+    else
+        echo -e "${RED}No persistence active. Nothing to sync.${NC}"
         exit 1
     fi
-    
-    echo "Persistence file: $persist_file"
-    
-    if [[ "$persist_file" == /dev/* ]]; then
-        echo "Using block device directly"
-        export MADOS_PERSISTENCE_DIR="$persist_file"
-    else
-        mkdir -p "$PERSISTENCE_MOUNT"
-        
-        if [[ "$persist_file" == *.dat ]]; then
-            local loop_dev=$(losetup -f --show "$persist_file" 2>/dev/null)
-            if [ -z "$loop_dev" ]; then
-                echo -e "${RED}Failed to create loop device${NC}"
-                exit 1
-            fi
-            mount -o rw "$loop_dev" "$PERSISTENCE_MOUNT"
-        else
-            mount -o rw "$persist_file" "$PERSISTENCE_MOUNT"
-        fi
-        
-        export MADOS_PERSISTENCE_DIR="$PERSISTENCE_MOUNT"
-    fi
-    
-    export MADOS_PERSISTENCE_ACTIVE=1
-    
-    echo -e "${GREEN}Persistence enabled!${NC}"
-    echo "Changes will now be saved to: $MADOS_PERSISTENCE_DIR"
-    echo ""
-    echo "Note: For permanent persistence, you need to:"
-    echo "  1. Boot with 'madOS Live with Persistence' option"
-    echo "  2. Or configure cow_device parameter in boot loader"
-}
-
-cmd_disable() {
-    echo "=== Disabling Persistence ==="
-    
-    if [ -d "$PERSISTENCE_MOUNT" ]; then
-        umount "$PERSISTENCE_MOUNT" 2>/dev/null || true
-    fi
-    
-    for loop_dev in $(losetup -j /mados-persistence.dat 2>/dev/null | cut -d: -f1); do
-        losetup -d "$loop_dev" 2>/dev/null || true
-    done
-    
-    unset MADOS_PERSISTENCE_ACTIVE
-    unset MADOS_PERSISTENCE_DIR
-    
-    echo -e "${GREEN}Persistence disabled${NC}"
 }
 
 cmd_info() {
-    print_status
-    
-    echo -e "${BLUE}=== MODOS DE PERSISTENCIA ===${NC}"
+    echo -e "${BLUE}=== madOS Persistence Guide ===${NC}"
     echo ""
-    echo -e "${GREEN}Opción 1: ISO simple (sin persistencia)${NC}"
-    echo "  dd if=mados.iso of=/dev/sdb"
-    echo "  Listo. Boot normal."
+    echo -e "${GREEN}Option 1: USB with persistence partition (recommended)${NC}"
+    echo "  1. Write the ISO to USB:"
+    echo "     sudo dd if=madOS.iso of=/dev/sdX bs=4M status=progress"
+    echo "  2. Create an ext4 partition on remaining USB space:"
+    echo "     sudo fdisk /dev/sdX   # Add new partition"
+    echo "     sudo mkfs.ext4 -L mados-persist /dev/sdX3"
+    echo "  3. Boot and select 'madOS Live with Persistence'"
+    echo "  4. The partition is auto-detected via cow_label=mados-persist"
     echo ""
-    echo -e "${GREEN}Opción 2: Ventoy (CON persistencia)${NC}"
-    echo "  1. Install Ventoy en USB"
-    echo "  2. Descargar script CreatePersistentImg.sh de ventoy.net"
-    echo "  3. sudo sh CreatePersistentImg.sh -s 4096 -l mados-persist"
-    echo "  4. Copiar mados-persistence.dat al USB (/ventoy/persistence/)"
-    echo "  5. Configurar ventoy.json"
+    echo -e "${GREEN}Option 2: Ventoy USB (persistence via Ventoy)${NC}"
+    echo "  1. Install Ventoy on USB: https://ventoy.net"
+    echo "  2. Copy madOS.iso to USB"
+    echo "  3. Create persistence image (on another PC):"
+    echo "     sudo sh CreatePersistentImg.sh -s 4096 -l mados-persist"
+    echo "     (Download from: https://ventoy.net/en/plugin_persistence.html)"
+    echo "  4. Copy persistence.dat to /ventoy/persistence/ on the USB"
+    echo "  5. Configure /ventoy/ventoy.json:"
+    echo '     {'
+    echo '       "persistence": [{'
+    echo '         "image": "/madOS.iso",'
+    echo '         "backend": "/ventoy/persistence/persistence.dat"'
+    echo '       }]'
+    echo '     }'
+    echo "  6. Ventoy handles persistence automatically at boot"
     echo ""
-    echo "Mas info: https://www.ventoy.net/en/plugin_persistence.html"
+    echo -e "${GREEN}Option 3: ISO without persistence${NC}"
+    echo "  Boot normally. All changes stay in RAM and are lost on reboot."
+    echo "  The 'madOS Live' option uses cow_spacesize=256M for temp storage."
     echo ""
-    echo "Comandos:"
-    echo "  mados-persistence status    # Ver estado"
-    echo "  mados-persistence info     # Esta ayuda"
+    echo -e "${YELLOW}Commands:${NC}"
+    echo "  mados-persistence status  # Check current persistence mode"
+    echo "  mados-persistence info    # This help"
+    echo "  mados-persistence sync    # Force sync (rsync mode only)"
 }
 
 case "${1:-status}" in
     status)
         cmd_status
         ;;
-    enable)
-        cmd_enable
-        ;;
-    disable)
-        cmd_disable
+    sync)
+        cmd_sync
         ;;
     info|--help|-h)
         cmd_info
         ;;
     *)
         echo "Unknown command: $1"
-        echo "Use: status, enable, disable, or info"
+        echo "Usage: mados-persistence {status|sync|info}"
         exit 1
         ;;
 esac

--- a/airootfs/usr/local/lib/mados_installer/config.py
+++ b/airootfs/usr/local/lib/mados_installer/config.py
@@ -106,6 +106,7 @@ PACKAGES_PHASE2 = [
     # madOS Native Apps Dependencies
     'python-pillow', 'poppler-glib',
     'gstreamer', 'gst-plugins-base', 'gst-plugins-good', 'gst-python',
+    'gst-plugins-ugly', 'gst-plugins-bad', 'gst-libav', 'gst-plugin-gtk',
 ]
 
 # Combined package list (all packages for both phases)

--- a/airootfs/usr/local/lib/mados_installer/pages/installation.py
+++ b/airootfs/usr/local/lib/mados_installer/pages/installation.py
@@ -1342,18 +1342,16 @@ if [ -f /etc/skel/.zshrc ]; then
     chown {username}:{username} /home/{username}/.zshrc
 fi
 
-# Ventoy persistence configuration
-VENTOY_PERSIST_SIZE={data.get("ventoy_persist_size", 4096)}
+# Ventoy/persistence configuration
 mkdir -p /etc/mados
-cat > /etc/mados/ventoy-persist.conf <<'EOFVENTOY'
-# madOS Ventoy Persistence Configuration
-# This file is read by mados-ventoy-setup.sh at boot
+cat > /etc/mados/ventoy-persist.conf << EOFVENTOY
+# madOS Persistence Configuration
+# Read by persistence detection at boot
 
-# Maximum size of persistence file in MB (default: 4096)
-# Valid values: 512 - 8192
+# Preferred persistence size in MB (used as reference for Ventoy .dat files)
 VENTOY_PERSIST_SIZE_MB={data.get("ventoy_persist_size", 4096)}
 
-# Minimum free space required on USB in MB (default: 512)
+# Minimum free space required on USB in MB
 MIN_FREE_SPACE_MB=512
 EOFVENTOY
 chmod 644 /etc/mados/ventoy-persist.conf

--- a/docs/index.html
+++ b/docs/index.html
@@ -80,7 +80,7 @@ layout: none
             "OpenCode AI integration",
             "Optimized for 1.9GB RAM systems",
             "Sway or Hyprland compositor with Nord theme (~300MB RAM)",
-            "Persistent USB live environment with auto-configured storage",
+            "Persistent USB via labeled partition (cow_label) or Ventoy",
             "GTK graphical installer with 6 languages",
             "ZRAM and EarlyOOM memory optimization",
             "Built-in WiFi configuration",
@@ -263,7 +263,7 @@ layout: none
                     </div>
                     <div class="feature-text">
                         <h3>Persistent USB</h3>
-                        <p>Auto-configured persistent storage. Use directly from USB across reboots.</p>
+                        <p>Create a labeled partition and your changes survive reboots. Works with Ventoy too.</p>
                     </div>
                 </div>
                 <div class="feature-card">
@@ -697,7 +697,7 @@ layout: none
                         </div>
                         <div class="step-content">
                             <h4>Ready!</h4>
-                            <p>AI assistant, dev tools & persistent storage out of the box</p>
+                            <p>AI assistant, dev tools & optional persistent USB storage</p>
                         </div>
                     </div>
                 </div>

--- a/grub/grub.cfg
+++ b/grub/grub.cfg
@@ -52,7 +52,10 @@ menuentry "madOS Live (%ARCH%, ${archiso_platform})" --class arch --class gnu-li
 
 menuentry "madOS Live with Persistence (%ARCH%, ${archiso_platform})" --class arch --class gnu-linux --class gnu --class os --id 'archlinux-persist' {
     set gfxpayload=keep
-    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% cow_spacesize=50% quiet splash
+    # Use cow_label to auto-detect a partition labeled 'mados-persist' for real persistence.
+    # If no such partition exists, archiso falls back to tmpfs (no persistence).
+    # To enable: create an ext4 partition labeled 'mados-persist' on the USB.
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% cow_label=mados-persist quiet splash
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
 }
 
@@ -64,7 +67,7 @@ menuentry "madOS Live (Safe Graphics) (%ARCH%, ${archiso_platform})" --hotkey s 
 
 menuentry "madOS Live with Persistence (Safe Graphics) (%ARCH%, ${archiso_platform})" --class arch --class gnu-linux --class gnu --class os --id 'archlinux-safe-persist' {
     set gfxpayload=keep
-    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% cow_spacesize=50% nomodeset quiet splash
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% cow_label=mados-persist nomodeset quiet splash
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
 }
 

--- a/grub/loopback.cfg
+++ b/grub/loopback.cfg
@@ -27,6 +27,14 @@ menuentry "madOS Live (%ARCH%, ${archiso_platform})" --class arch --class gnu-li
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
 }
 
+menuentry "madOS Live with Persistence (%ARCH%, ${archiso_platform})" --class arch --class gnu-linux --class gnu --class os --id 'archlinux-persist' {
+    set gfxpayload=keep
+    # Persistence via cow_label: requires a partition labeled 'mados-persist' on the USB.
+    # For Ventoy: configure persistence in ventoy.json instead.
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% img_dev=UUID=${archiso_img_dev_uuid} img_loop="${iso_path}" cow_label=mados-persist quiet splash
+    initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
+}
+
 menuentry "madOS Live (Safe Graphics) (%ARCH%, ${archiso_platform})" --hotkey s --class arch --class gnu-linux --class gnu --class os --id 'archlinux-safe' {
     set gfxpayload=keep
     linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% img_dev=UUID=${archiso_img_dev_uuid} img_loop="${iso_path}" cow_spacesize=256M nomodeset quiet splash

--- a/packages.x86_64
+++ b/packages.x86_64
@@ -169,6 +169,7 @@ python-pillow
 gst-plugins-ugly
 gst-plugins-bad
 gst-libav
+gst-plugin-gtk
 
 # madOS PDF Viewer - PDF rendering and annotations
 poppler-glib

--- a/profiledef.sh
+++ b/profiledef.sh
@@ -70,6 +70,7 @@ file_permissions=(
   ["/usr/local/lib/mados_audio_player/"]="0:0:755"
   ["/usr/local/lib/mados-media-helper.sh"]="0:0:755"
   ["/usr/local/bin/mados-persistence"]="0:0:755"
+  ["/usr/local/bin/mados-installer-autostart"]="0:0:755"
   ["/usr/local/bin/mados-vbox-guest"]="0:0:755"
   ["/usr/local/bin/mados-persist-sync.sh"]="0:0:755"
   ["/usr/local/bin/mados-persist-detect.sh"]="0:0:755"

--- a/syslinux/archiso_sys-linux.cfg
+++ b/syslinux/archiso_sys-linux.cfg
@@ -10,12 +10,12 @@ APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% cow_spacesi
 
 LABEL arch-persist
 TEXT HELP
-Boot madOS Live with persistence enabled. Your changes will be saved.
+Boot madOS Live with persistence. Requires a partition labeled 'mados-persist'.
 ENDTEXT
 MENU LABEL madOS Live with Persistence (%ARCH%, BIOS)
 LINUX /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux
 INITRD /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
-APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% cow_spacesize=50% quiet splash
+APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% cow_label=mados-persist quiet splash
 
 # Safe graphics boot option
 LABEL archsafe

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """
-Tests for madOS persistence scripts (Ventoy-style).
+Tests for madOS persistence scripts.
 
 Validates that persistence scripts are properly configured:
   - All persistence scripts exist and are executable
-  - Systemd services reference valid scripts
+  - Systemd services reference valid scripts and have correct Type
   - Shell scripts have valid bash syntax
-  - Configuration files are valid
+  - Services are properly chained (ventoy-setup → detect → sync)
+  - GRUB/syslinux entries use cow_label for real persistence
+  - State file path is consistent across scripts
 """
 
 import os
@@ -17,6 +19,8 @@ REPO_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 AIROOTFS = os.path.join(REPO_DIR, "airootfs")
 BIN_DIR = os.path.join(AIROOTFS, "usr", "local", "bin")
 SYSTEMD_DIR = os.path.join(AIROOTFS, "etc", "systemd", "system")
+GRUB_DIR = os.path.join(REPO_DIR, "grub")
+SYSLINUX_DIR = os.path.join(REPO_DIR, "syslinux")
 
 
 class TestPersistenceScriptsExist(unittest.TestCase):
@@ -33,6 +37,10 @@ class TestPersistenceScriptsExist(unittest.TestCase):
     def test_mados_persist_detect_exists(self):
         path = os.path.join(BIN_DIR, "mados-persist-detect.sh")
         self.assertTrue(os.path.exists(path), "mados-persist-detect.sh not found")
+
+    def test_mados_ventoy_setup_exists(self):
+        path = os.path.join(BIN_DIR, "mados-ventoy-setup.sh")
+        self.assertTrue(os.path.exists(path), "mados-ventoy-setup.sh not found")
 
 
 class TestPersistenceScriptsExecutable(unittest.TestCase):
@@ -54,6 +62,12 @@ class TestPersistenceScriptsExecutable(unittest.TestCase):
             os.access(path, os.X_OK), "mados-persist-detect.sh not executable"
         )
 
+    def test_mados_ventoy_setup_is_executable(self):
+        path = os.path.join(BIN_DIR, "mados-ventoy-setup.sh")
+        self.assertTrue(
+            os.access(path, os.X_OK), "mados-ventoy-setup.sh not executable"
+        )
+
 
 class TestPersistenceScriptsSyntax(unittest.TestCase):
     """Test that shell scripts have valid bash syntax."""
@@ -65,6 +79,16 @@ class TestPersistenceScriptsSyntax(unittest.TestCase):
 
     def test_mados_persist_detect_syntax(self):
         path = os.path.join(BIN_DIR, "mados-persist-detect.sh")
+        result = subprocess.run(["bash", "-n", path], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, f"Syntax error: {result.stderr}")
+
+    def test_mados_ventoy_setup_syntax(self):
+        path = os.path.join(BIN_DIR, "mados-ventoy-setup.sh")
+        result = subprocess.run(["bash", "-n", path], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, f"Syntax error: {result.stderr}")
+
+    def test_mados_persistence_cli_syntax(self):
+        path = os.path.join(BIN_DIR, "mados-persistence")
         result = subprocess.run(["bash", "-n", path], capture_output=True, text=True)
         self.assertEqual(result.returncode, 0, f"Syntax error: {result.stderr}")
 
@@ -80,6 +104,12 @@ class TestPersistenceServicesExist(unittest.TestCase):
         path = os.path.join(SYSTEMD_DIR, "mados-persistence-detect.service")
         self.assertTrue(
             os.path.exists(path), "mados-persistence-detect.service not found"
+        )
+
+    def test_mados_ventoy_setup_service_exists(self):
+        path = os.path.join(SYSTEMD_DIR, "mados-ventoy-setup.service")
+        self.assertTrue(
+            os.path.exists(path), "mados-ventoy-setup.service not found"
         )
 
 
@@ -114,39 +144,300 @@ class TestPersistenceServiceReferences(unittest.TestCase):
             "Service does not reference mados-persist-detect.sh",
         )
 
+    def test_mados_ventoy_setup_service_references_script(self):
+        service_path = os.path.join(SYSTEMD_DIR, "mados-ventoy-setup.service")
+        if not os.path.exists(service_path):
+            self.skipTest("Service file not found")
+
+        with open(service_path, "r") as f:
+            content = f.read()
+
+        self.assertIn(
+            "mados-ventoy-setup.sh",
+            content,
+            "Service does not reference mados-ventoy-setup.sh",
+        )
+
+
+class TestPersistenceServiceTypes(unittest.TestCase):
+    """Test that services use correct Type= values."""
+
+    def _read_service(self, name):
+        path = os.path.join(SYSTEMD_DIR, name)
+        if not os.path.exists(path):
+            self.skipTest(f"{name} not found")
+        with open(path, "r") as f:
+            return f.read()
+
+    def test_sync_service_is_simple(self):
+        """persist-sync runs a blocking loop, must be Type=simple, not forking."""
+        content = self._read_service("mados-persist-sync.service")
+        self.assertIn("Type=simple", content)
+        self.assertNotIn("Type=forking", content)
+
+    def test_detect_service_is_oneshot(self):
+        content = self._read_service("mados-persistence-detect.service")
+        self.assertIn("Type=oneshot", content)
+
+    def test_ventoy_setup_service_is_oneshot(self):
+        content = self._read_service("mados-ventoy-setup.service")
+        self.assertIn("Type=oneshot", content)
+
+
+class TestPersistenceServiceChain(unittest.TestCase):
+    """Test that services are properly chained in execution order."""
+
+    def _read_service(self, name):
+        path = os.path.join(SYSTEMD_DIR, name)
+        if not os.path.exists(path):
+            self.skipTest(f"{name} not found")
+        with open(path, "r") as f:
+            return f.read()
+
+    def test_detect_runs_after_ventoy_setup(self):
+        content = self._read_service("mados-persistence-detect.service")
+        self.assertIn("After=mados-ventoy-setup.service", content)
+
+    def test_sync_runs_after_detect(self):
+        content = self._read_service("mados-persist-sync.service")
+        self.assertIn("After=mados-persistence-detect.service", content)
+
+    def test_detect_requires_ventoy_setup(self):
+        content = self._read_service("mados-persistence-detect.service")
+        self.assertIn("Requires=mados-ventoy-setup.service", content)
+
+    def test_sync_requires_detect(self):
+        content = self._read_service("mados-persist-sync.service")
+        self.assertIn("Requires=mados-persistence-detect.service", content)
+
+
+class TestPersistenceServicesEnabled(unittest.TestCase):
+    """Test that all persistence services are enabled (have symlinks)."""
+
+    WANTS_DIR = os.path.join(SYSTEMD_DIR, "multi-user.target.wants")
+
+    def test_ventoy_setup_enabled(self):
+        link = os.path.join(self.WANTS_DIR, "mados-ventoy-setup.service")
+        self.assertTrue(
+            os.path.islink(link) or os.path.exists(link),
+            "mados-ventoy-setup.service not enabled in multi-user.target.wants",
+        )
+
+    def test_persistence_detect_enabled(self):
+        link = os.path.join(self.WANTS_DIR, "mados-persistence-detect.service")
+        self.assertTrue(
+            os.path.islink(link) or os.path.exists(link),
+            "mados-persistence-detect.service not enabled in multi-user.target.wants",
+        )
+
+    def test_persist_sync_enabled(self):
+        link = os.path.join(self.WANTS_DIR, "mados-persist-sync.service")
+        self.assertTrue(
+            os.path.islink(link) or os.path.exists(link),
+            "mados-persist-sync.service not enabled in multi-user.target.wants",
+        )
+
 
 class TestPersistenceCLICommands(unittest.TestCase):
     """Test that mados-persistence CLI has expected commands."""
 
-    def test_mados_persistence_has_status_command(self):
-        path = os.path.join(BIN_DIR, "mados-persistence")
-        if not os.path.exists(path):
+    def setUp(self):
+        self.path = os.path.join(BIN_DIR, "mados-persistence")
+        if not os.path.exists(self.path):
             self.skipTest("CLI not found")
+        with open(self.path, "r") as f:
+            self.content = f.read()
 
+    def test_has_status_command(self):
+        self.assertIn("status", self.content, "CLI missing 'status' command")
+
+    def test_has_info_command(self):
+        self.assertIn("info", self.content, "CLI missing 'info' command")
+
+    def test_has_sync_command(self):
+        self.assertIn("sync", self.content, "CLI missing 'sync' command")
+
+    def test_has_ventoy_docs(self):
+        self.assertIn("Ventoy", self.content, "CLI missing Ventoy documentation")
+
+    def test_reads_state_file(self):
+        self.assertIn(
+            "/run/mados-persist.env",
+            self.content,
+            "CLI should read state from /run/mados-persist.env",
+        )
+
+    def test_no_broken_enable_disable(self):
+        """CLI should not have enable/disable commands that export useless vars."""
+        # These were removed because export in a script doesn't affect parent shell
+        self.assertNotIn(
+            "cmd_enable",
+            self.content,
+            "CLI should not have broken enable command",
+        )
+        self.assertNotIn(
+            "cmd_disable",
+            self.content,
+            "CLI should not have broken disable command",
+        )
+
+
+class TestPersistenceStateFileConsistency(unittest.TestCase):
+    """Test that all scripts use the same state file path."""
+
+    STATE_FILE_PATH = "/run/mados-persist.env"
+
+    def test_ventoy_setup_writes_state_file(self):
+        path = os.path.join(BIN_DIR, "mados-ventoy-setup.sh")
         with open(path, "r") as f:
             content = f.read()
+        self.assertIn(self.STATE_FILE_PATH, content)
 
-        self.assertIn("status", content, "CLI missing 'status' command")
-
-    def test_mados_persistence_has_info_command(self):
-        path = os.path.join(BIN_DIR, "mados-persistence")
-        if not os.path.exists(path):
-            self.skipTest("CLI not found")
-
+    def test_persist_detect_reads_state_file(self):
+        path = os.path.join(BIN_DIR, "mados-persist-detect.sh")
         with open(path, "r") as f:
             content = f.read()
+        self.assertIn(self.STATE_FILE_PATH, content)
 
-        self.assertIn("info", content, "CLI missing 'info' command")
-
-    def test_mados_persistence_has_ventoy_docs(self):
-        path = os.path.join(BIN_DIR, "mados-persistence")
-        if not os.path.exists(path):
-            self.skipTest("CLI not found")
-
+    def test_persist_sync_reads_state_file(self):
+        path = os.path.join(BIN_DIR, "mados-persist-sync.sh")
         with open(path, "r") as f:
             content = f.read()
+        self.assertIn(self.STATE_FILE_PATH, content)
 
-        self.assertIn("Ventoy", content, "CLI missing Ventoy documentation")
+    def test_cli_reads_state_file(self):
+        path = os.path.join(BIN_DIR, "mados-persistence")
+        with open(path, "r") as f:
+            content = f.read()
+        self.assertIn(self.STATE_FILE_PATH, content)
+
+
+class TestPersistenceVentoySetupNoCreation(unittest.TestCase):
+    """Test that ventoy-setup.sh does NOT attempt to create persistence during boot."""
+
+    def setUp(self):
+        path = os.path.join(BIN_DIR, "mados-ventoy-setup.sh")
+        with open(path, "r") as f:
+            self.content = f.read()
+
+    def test_no_dd_command(self):
+        """Should not use dd to create files on the USB during boot."""
+        self.assertNotIn(
+            "dd if=/dev/zero",
+            self.content,
+            "ventoy-setup.sh should NOT create files with dd during boot",
+        )
+
+    def test_no_mkfs(self):
+        """Should not format anything during boot."""
+        self.assertNotIn(
+            "mkfs.ext4",
+            self.content,
+            "ventoy-setup.sh should NOT format filesystems during boot",
+        )
+
+    def test_no_parted(self):
+        """Should not try to partition the USB during boot."""
+        self.assertNotIn(
+            "parted",
+            self.content,
+            "ventoy-setup.sh should NOT partition disks during boot",
+        )
+
+    def test_writes_state_file(self):
+        """Should write detection results to state file."""
+        self.assertIn("write_state", self.content)
+
+
+class TestGrubPersistenceEntries(unittest.TestCase):
+    """Test that GRUB entries use cow_label for real persistence."""
+
+    def setUp(self):
+        grub_path = os.path.join(GRUB_DIR, "grub.cfg")
+        with open(grub_path, "r") as f:
+            self.grub_content = f.read()
+
+    def test_persistence_entry_uses_cow_label(self):
+        """Persistence entries should use cow_label=mados-persist, not just cow_spacesize."""
+        self.assertIn(
+            "cow_label=mados-persist",
+            self.grub_content,
+            "GRUB persistence entries must use cow_label=mados-persist for real persistence",
+        )
+
+    def test_no_persistence_entry_with_only_cow_spacesize(self):
+        """Persistence entries should NOT rely only on cow_spacesize (which is just RAM)."""
+        # Find lines with "Persistence" in menuentry that also have cow_spacesize but no cow_label
+        lines = self.grub_content.split("\n")
+        for i, line in enumerate(lines):
+            if "Persistence" in line and "menuentry" in line:
+                # Check the linux line (next few lines)
+                block = "\n".join(lines[i : i + 5])
+                if "cow_spacesize" in block:
+                    self.assertIn(
+                        "cow_label",
+                        block,
+                        f"Persistence entry at line {i+1} uses cow_spacesize without cow_label",
+                    )
+
+
+class TestLoopbackPersistenceEntry(unittest.TestCase):
+    """Test that loopback.cfg (used by Ventoy) has persistence option."""
+
+    def setUp(self):
+        path = os.path.join(GRUB_DIR, "loopback.cfg")
+        with open(path, "r") as f:
+            self.content = f.read()
+
+    def test_has_persistence_entry(self):
+        self.assertIn(
+            "Persistence",
+            self.content,
+            "loopback.cfg should have a persistence menu entry for Ventoy users",
+        )
+
+    def test_persistence_uses_cow_label(self):
+        self.assertIn(
+            "cow_label=mados-persist",
+            self.content,
+            "loopback.cfg persistence entry should use cow_label=mados-persist",
+        )
+
+
+class TestSyslinuxPersistenceEntries(unittest.TestCase):
+    """Test that syslinux entries use cow_label for persistence."""
+
+    def setUp(self):
+        path = os.path.join(SYSLINUX_DIR, "archiso_sys-linux.cfg")
+        with open(path, "r") as f:
+            self.content = f.read()
+
+    def test_persistence_entry_uses_cow_label(self):
+        self.assertIn(
+            "cow_label=mados-persist",
+            self.content,
+            "Syslinux persistence entry must use cow_label=mados-persist",
+        )
+
+
+class TestVentoyPersistConfig(unittest.TestCase):
+    """Test that the ventoy-persist.conf is valid."""
+
+    def test_config_exists(self):
+        path = os.path.join(AIROOTFS, "etc", "mados", "ventoy-persist.conf")
+        self.assertTrue(os.path.exists(path))
+
+    def test_config_has_size(self):
+        path = os.path.join(AIROOTFS, "etc", "mados", "ventoy-persist.conf")
+        with open(path, "r") as f:
+            content = f.read()
+        self.assertIn("VENTOY_PERSIST_SIZE_MB", content)
+
+    def test_config_has_min_free_space(self):
+        path = os.path.join(AIROOTFS, "etc", "mados", "ventoy-persist.conf")
+        with open(path, "r") as f:
+            content = f.read()
+        self.assertIn("MIN_FREE_SPACE_MB", content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Refactor persistence scripts (detect, sync, management CLI) for clarity and robustness
- Simplify systemd service files for persistence and Ventoy setup
- Improve Ventoy setup script with streamlined logic
- Enhance equalizer backend with expanded functionality
- Add installer autostart script and update Sway autostart config
- Add Ventoy loopback support in GRUB config
- Update installer config and installation page
- Add mados-installer-autostart to profiledef.sh permissions
- Enable persistence services via systemd symlinks
- Add pipewire-alsa package
- Expand equalizer backend and persistence test coverage
- Update docs/index.html version info