### PR TITLE
fix: resolve SonarQube alerts across shell scripts and Python modules

### DIFF
--- a/airootfs/usr/local/bin/mados-persist-detect.sh
+++ b/airootfs/usr/local/bin/mados-persist-detect.sh
@@ -16,11 +16,13 @@ STATE_FILE="/run/mados-persist.env"
 PERSISTENCE_MOUNT="/mnt/mados-persist"
 
 log() {
-    echo "[mados-persist-detect] $1"
+    local msg="$1"
+    echo "[mados-persist-detect] $msg"
+    return 0
 }
 
 read_state() {
-    if [ -f "$STATE_FILE" ]; then
+    if [[ -f "$STATE_FILE" ]]; then
         # shellcheck source=/dev/null
         . "$STATE_FILE"
         return 0
@@ -48,7 +50,7 @@ mount_persistence_source() {
         # File (.dat) - set up loop device
         local loop_dev
         loop_dev=$(losetup -f --show "$source" 2>/dev/null)
-        if [ -z "$loop_dev" ]; then
+        if [[ -z "$loop_dev" ]]; then
             log "ERROR: Failed to create loop device for $source"
             return 1
         fi
@@ -81,7 +83,7 @@ main() {
             ;;
         partition|file)
             # rsync-based persistence: mount the source for the sync service
-            if [ -n "$MADOS_PERSIST_DEVICE" ]; then
+            if [[ -n "$MADOS_PERSIST_DEVICE" ]]; then
                 if mount_persistence_source "$MADOS_PERSIST_DEVICE"; then
                     log "Persistence source mounted at $PERSISTENCE_MOUNT"
                 else
@@ -93,6 +95,8 @@ main() {
             log "No persistence active"
             ;;
     esac
+
+    return 0
 }
 
 main "$@"

--- a/airootfs/usr/local/bin/mados-persist-sync.sh
+++ b/airootfs/usr/local/bin/mados-persist-sync.sh
@@ -29,7 +29,7 @@ log() {
 }
 
 read_state() {
-    if [ -f "$STATE_FILE" ]; then
+    if [[ -f "$STATE_FILE" ]]; then
         # shellcheck source=/dev/null
         . "$STATE_FILE"
         return 0
@@ -43,6 +43,7 @@ is_rsync_mode() {
         partition|file) return 0 ;;
         *) return 1 ;;
     esac
+    return 1
 }
 
 is_persistence_mounted() {
@@ -74,7 +75,7 @@ sync_to_persistence() {
         /root/ "$persist_dir/root/" 2>/dev/null
 
     # /etc/mados - madOS configuration
-    if [ -d /etc/mados ]; then
+    if [[ -d /etc/mados ]]; then
         mkdir -p "$persist_dir/etc.mados/"
         rsync -a --delete \
             /etc/mados/ "$persist_dir/etc.mados/" 2>/dev/null
@@ -91,7 +92,7 @@ load_from_persistence() {
         return 1
     fi
 
-    if [ -z "$(ls -A "$persist_dir" 2>/dev/null)" ]; then
+    if [[ -z "$(ls -A "$persist_dir" 2>/dev/null)" ]]; then
         log "Persistence mount is empty, nothing to load"
         return 1
     fi
@@ -99,19 +100,19 @@ load_from_persistence() {
     log "Loading persisted data..."
 
     # /home
-    if [ -d "$persist_dir/home" ]; then
+    if [[ -d "$persist_dir/home" ]]; then
         rsync -a "$persist_dir/home/" /home/ 2>/dev/null
         log "Restored /home"
     fi
 
     # /root
-    if [ -d "$persist_dir/root" ]; then
+    if [[ -d "$persist_dir/root" ]]; then
         rsync -a "$persist_dir/root/" /root/ 2>/dev/null
         log "Restored /root"
     fi
 
     # /etc/mados
-    if [ -d "$persist_dir/etc.mados" ]; then
+    if [[ -d "$persist_dir/etc.mados" ]]; then
         mkdir -p /etc/mados
         rsync -a "$persist_dir/etc.mados/" /etc/mados/ 2>/dev/null
         log "Restored /etc/mados"
@@ -125,7 +126,7 @@ start_service() {
 
     if ! is_rsync_mode; then
         local mode="${MADOS_PERSIST_MODE:-unknown}"
-        if [ "$mode" = "cow_device" ] || [ "$mode" = "cow_label" ]; then
+        if [[ "$mode" = "cow_device" ]] || [[ "$mode" = "cow_label" ]]; then
             log "Archiso native persistence active, rsync not needed"
         else
             log "No rsync-based persistence configured (mode=$mode)"
@@ -157,6 +158,7 @@ stop_service() {
     log "Stopping persistence sync..."
     sync_to_persistence
     log "Final sync complete"
+    return 0
 }
 
 case "${1:-start}" in

--- a/tests/test_equalizer_backend.py
+++ b/tests/test_equalizer_backend.py
@@ -519,7 +519,7 @@ class TestApplyEq(unittest.TestCase):
         mock_start.return_value = True
         mock_set_sink.return_value = True
 
-        success, message = self.backend.apply_eq(gains=[0.0] * 8)
+        success, _ = self.backend.apply_eq(gains=[0.0] * 8)
 
         self.assertTrue(success)
         mock_set_sink.assert_called_once()
@@ -722,7 +722,7 @@ class TestDefaultSinkRouting(unittest.TestCase):
         """disable_eq should restore the original default sink."""
         self.backend.has_pipewire = True
 
-        success, message = self.backend.disable_eq()
+        success, _ = self.backend.disable_eq()
 
         self.assertTrue(success)
         mock_restore.assert_called_once()


### PR DESCRIPTION
- mados-persist-detect.sh: use [[ ]], assign positional params to local vars, add explicit returns
- mados-persist-sync.sh: use [[ ]], add explicit returns to functions
- mados-ventoy-setup.sh: use [[ ]], assign positional params, add default case in case statements, add explicit returns
- backend.py: reduce cognitive complexity by extracting _parse_id_from_line, _parse_node_id_from_inspect, _parse_eq_sink_from_objects helpers
- test_equalizer_backend.py: replace unused 'message' variable with '_'