### PR TITLE
fix(docs): update download button to v1.15.1

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -630,13 +630,13 @@ layout: none
                     <div class="download-info">
                         <h3>Download ISO</h3>
                         <p>Get the latest official release</p>
-                        <a href="https://archive.org/download/mados-dev-20260223/madOS-dev-2026.02.23-1805-x86_64.iso" target="_blank" rel="noopener" class="btn btn-primary btn-download" data-version="dev-20260223">
+                        <a href="https://archive.org/download/mados-dev-20260223/madOS-dev-2026.02.23-1805-x86_64.iso" target="_blank" rel="noopener" class="btn btn-primary btn-download" data-version="v1.15.1">
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
                                 <polyline points="7 10 12 15 17 10"></polyline>
                                 <line x1="12" y1="15" x2="12" y2="3"></line>
                             </svg>
-                            <span>Download vdev-20260223</span>
+                            <span>Download v1.15.1</span>
                         </a>
                         <a href="https://github.com/madkoding/mad-os/releases/latest" target="_blank" rel="noopener" class="download-checksums">View checksums on GitHub</a>
                     </div>


### PR DESCRIPTION
## Hotfix: Download Button Version

Corrige el botón de descarga en GitHub Pages para mostrar el tag más reciente (v1.15.1) en lugar de la versión dev.

### Cambios
- Texto del botón: `Download vdev-20260223` → `Download v1.15.1`
- data-version: `dev-20260223` → `v1.15.1`
- URL de descarga sin cambios (misma ISO en Internet Archive)