### PR TITLE
fix(ci): fix VERSION env var case mismatch in CI workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -395,7 +395,7 @@ jobs:
             echo "is_prerelease=${{ needs.auto-tag.outputs.is_prerelease }}" >> "$GITHUB_OUTPUT"
             echo "release_type=${{ needs.auto-tag.outputs.release_type }}" >> "$GITHUB_OUTPUT"
             echo "auto_tag=$AUTO_TAG" >> "$GITHUB_OUTPUT"
-            echo "version=$AUTO_VERSION" >> "$GITHUB_ENV"
+            echo "VERSION=$AUTO_VERSION" >> "$GITHUB_ENV"
 
           elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             # Manual tag push: use the tag as-is
@@ -422,7 +422,7 @@ jobs:
               echo "auto_tag=" >> "$GITHUB_OUTPUT"
             fi
             VERSION="${TAG#v}"
-            echo "version=$VERSION" >> "$GITHUB_ENV"
+            echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
           else
             # Manual dispatch or other

--- a/docs/index.html
+++ b/docs/index.html
@@ -630,13 +630,13 @@ layout: none
                     <div class="download-info">
                         <h3>Download ISO</h3>
                         <p>Get the latest official release</p>
-                        <a href="https://archive.org/download/mados-beta-dev-20260223-561bb9e/madOS-dev-2026.02.23-1804-x86_64.iso" target="_blank" rel="noopener" class="btn btn-primary btn-download" data-version="dev-20260223">
+                        <a href="https://archive.org/download/mados-dev-20260223/madOS-dev-2026.02.23-1805-x86_64.iso" target="_blank" rel="noopener" class="btn btn-primary btn-download" data-version="v1.15.1">
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
                                 <polyline points="7 10 12 15 17 10"></polyline>
                                 <line x1="12" y1="15" x2="12" y2="3"></line>
                             </svg>
-                            <span>Download vdev-20260223</span>
+                            <span>Download v1.15.1</span>
                         </a>
                         <a href="https://github.com/madkoding/mad-os/releases/latest" target="_blank" rel="noopener" class="download-checksums">View checksums on GitHub</a>
                     </div>


### PR DESCRIPTION
## Hotfix: VERSION case mismatch

### Root Cause
El step `build_type` escribía `version` (minúscula) en `$GITHUB_ENV`, pero `iso_info` leía `$VERSION` (mayúscula). En Linux las env vars son case-sensitive, así que la versión siempre era vacía y caía al fallback `dev-YYYYMMDD`.

Esto causaba que el job `update-website` sobreescribiera el botón de descarga con `Download vdev-YYYYMMDD` en vez del tag real.

### Cambios
- `.github/workflows/ci-cd.yml`: Corregido `version` → `VERSION` en las dos líneas de `$GITHUB_ENV`
- `docs/index.html`: Restaurado botón a `Download v1.15.1` con URL correcta de Internet Archive